### PR TITLE
108 investigate cooldowns

### DIFF
--- a/System Miami/Assets/_Project/Combat/Combat Action/Ability/Classes/NewAbility.cs
+++ b/System Miami/Assets/_Project/Combat/Combat Action/Ability/Classes/NewAbility.cs
@@ -13,13 +13,13 @@ namespace SystemMiami.CombatRefactor
         public readonly int CooldownTurns;
 
         private Action<float> looseResource;
-        private int cooldownRemaining;
+        public int CooldownRemaining { get; private set; }
 
         public bool IsOnCooldown
         {
             get
             {
-                return cooldownRemaining > 0;
+                return CooldownRemaining > 0;
             }
         }
 
@@ -38,9 +38,9 @@ namespace SystemMiami.CombatRefactor
 
         public void ReduceCooldown()
         {
-            if (cooldownRemaining > 0)
+            if (CooldownRemaining > 0)
             {
-                cooldownRemaining--;
+                CooldownRemaining--;
             }
         }
 
@@ -51,11 +51,12 @@ namespace SystemMiami.CombatRefactor
 
         protected override void PostExecution()
         {
-            startCooldown();
+            StartCooldown();
         }
-        private void startCooldown()
+
+        private void StartCooldown()
         {
-            cooldownRemaining = CooldownTurns;
+            CooldownRemaining = CooldownTurns;
         }
     }
 }

--- a/System Miami/Assets/_Project/Combat/Combat Action/Consumable/Consumable.cs
+++ b/System Miami/Assets/_Project/Combat/Combat Action/Consumable/Consumable.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System;
 using SystemMiami.CombatSystem;
 using System.Linq;
+using UnityEngine;
 
 namespace SystemMiami.CombatRefactor
 {
@@ -11,21 +12,13 @@ namespace SystemMiami.CombatRefactor
 
         public readonly int MaxUses;
 
-        private int usesRemaining;
-
-        public int UsesRemaining
-        {
-            get
-            {
-                return usesRemaining;
-            }
-        }
+        public int UsesRemaining { get; private set; }
 
         public bool IsEmpty
         {
             get
             {
-                return usesRemaining <= 0;
+                return UsesRemaining <= 0;
             }
         }
 
@@ -36,17 +29,18 @@ namespace SystemMiami.CombatRefactor
                   preset.OverrideController,
                   user)
         {
-            MaxUses = preset.Uses;
+            MaxUses = (int)Mathf.Clamp(preset.Uses, 1, Mathf.Infinity);
+            UsesRemaining = MaxUses;
         }
 
         protected override void PreExecution()
         {
-            usesRemaining--;
+            UsesRemaining--;
         }
 
         protected override void PostExecution()
         {
-            if (usesRemaining <= 0)
+            if (UsesRemaining <= 0)
             {
                 Consumed?.Invoke(this);
             }

--- a/System Miami/Assets/_Project/Combat/Loadout/Loadout.cs
+++ b/System Miami/Assets/_Project/Combat/Loadout/Loadout.cs
@@ -136,8 +136,7 @@ namespace SystemMiami.CombatRefactor
         public void ReduceCooldowns()
         {
             PhysicalAbilities.ForEach(a => a.ReduceCooldown());
-            MagicalAbilities.ForEach(a => a.ReduceCooldown());
-            
+            MagicalAbilities.ForEach(a => a.ReduceCooldown());            
         }
 
        

--- a/System Miami/Assets/_Project/Combat/TurnManager.cs
+++ b/System Miami/Assets/_Project/Combat/TurnManager.cs
@@ -149,7 +149,7 @@ namespace SystemMiami
         {
             
             bool combatantsReady = true;
-           
+            
             do
             {
                 combatantsReady = true;

--- a/System Miami/Assets/_Project/Dungeon/Scenes/In Build/Dungeon.unity
+++ b/System Miami/Assets/_Project/Dungeon/Scenes/In Build/Dungeon.unity
@@ -13147,19 +13147,13 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 3971718204096858350}
     - target: {fileID: 707335842633278732, guid: 6cdde11d2c7c6e240904227cbaa2b324, type: 3}
-      propertyPath: enabledStr
-      value: ENABLED
-      objectReference: {fileID: 0}
-    - target: {fileID: 707335842633278732, guid: 6cdde11d2c7c6e240904227cbaa2b324, type: 3}
-      propertyPath: cooldownStr
-      value: 'ON COOLDOWN
-
-        Enabled in <> Turns'
-      objectReference: {fileID: 0}
-    - target: {fileID: 707335842633278732, guid: 6cdde11d2c7c6e240904227cbaa2b324, type: 3}
       propertyPath: DescriptionText
       value: 
       objectReference: {fileID: 7058314808775729815}
+    - target: {fileID: 707335842633278732, guid: 6cdde11d2c7c6e240904227cbaa2b324, type: 3}
+      propertyPath: StatusIndicator
+      value: 
+      objectReference: {fileID: 907460035}
     - target: {fileID: 707335842633278732, guid: 6cdde11d2c7c6e240904227cbaa2b324, type: 3}
       propertyPath: CooldownIndicator
       value: 

--- a/System Miami/Assets/_Project/Dungeon/Scenes/Popup Testing.meta
+++ b/System Miami/Assets/_Project/Dungeon/Scenes/Popup Testing.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5695661564935cc419f46f049482ba73
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/System Miami/Assets/_Project/Dungeon/Scenes/Popup Testing/Popup Testing Dungeon.unity
+++ b/System Miami/Assets/_Project/Dungeon/Scenes/Popup Testing/Popup Testing Dungeon.unity
@@ -4340,8 +4340,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0, y: 80}
-  m_SizeDelta: {x: -40, y: 40}
+  m_AnchoredPosition: {x: 0, y: 199}
+  m_SizeDelta: {x: -40, y: 90}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &907460035
 MonoBehaviour:
@@ -4356,7 +4356,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.5283019, g: 0, b: 0, a: 1}
+  m_Color: {r: 0.23584908, g: 0, b: 0, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -4370,7 +4370,7 @@ MonoBehaviour:
     m_BestFit: 1
     m_MinSize: 2
     m_MaxSize: 300
-    m_Alignment: 0
+    m_Alignment: 3
     m_AlignByGeometry: 1
     m_RichText: 1
     m_HorizontalOverflow: 0
@@ -10973,7 +10973,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
   m_AnchoredPosition: {x: 0, y: 20}
-  m_SizeDelta: {x: -40, y: 60}
+  m_SizeDelta: {x: -40, y: 90}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &2997545395677482418
 MonoBehaviour:
@@ -13363,8 +13363,8 @@ MonoBehaviour:
     m_BestFit: 1
     m_MinSize: 2
     m_MaxSize: 300
-    m_Alignment: 3
-    m_AlignByGeometry: 1
+    m_Alignment: 0
+    m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0

--- a/System Miami/Assets/_Project/Dungeon/Scenes/Popup Testing/Popup Testing Dungeon.unity.meta
+++ b/System Miami/Assets/_Project/Dungeon/Scenes/Popup Testing/Popup Testing Dungeon.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d6d4deba766ad6a40ae873ad087a875e
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/System Miami/Assets/_Project/Dungeon/UI/Alec Random Stuff/PopUpHandler.cs
+++ b/System Miami/Assets/_Project/Dungeon/UI/Alec Random Stuff/PopUpHandler.cs
@@ -13,9 +13,10 @@ namespace SystemMiami.ui
         public RectTransform Popup;
         public Text ItemName;
         public Text DescriptionText;
-        public Text CooldownIndicator;
+        public Text StatusIndicator;
         [TextArea] public string enabledStr;
         [TextArea] public string cooldownStr;
+        [TextArea] public string usesRemainingStr;
 
         public ItemData CurrentItemData;
         public Vector2 offset;
@@ -50,9 +51,13 @@ namespace SystemMiami.ui
 
             if (combatAction is NewAbility ability)
             {
-                CooldownIndicator.text = ability.IsOnCooldown
+                StatusIndicator.text = ability.IsOnCooldown
                     ? cooldownStr.Replace("<>", ability.CooldownRemaining.ToString())
                     : enabledStr;
+            }
+            else if (combatAction is Consumable consumable)
+            {
+                StatusIndicator.text = usesRemainingStr.Replace("<>", consumable.UsesRemaining.ToString());
             }
 
             OpenPopup(itemData, slot.RT, true);
@@ -60,6 +65,8 @@ namespace SystemMiami.ui
 
         public void OpenPopup(ItemData itemData, InventoryItemSlot slot)
         {
+            StatusIndicator.text = "";
+
             OpenPopup(itemData, slot.RT, false);
         }
 

--- a/System Miami/Assets/_Project/Dungeon/UI/Alec Random Stuff/PopUpHandler.cs
+++ b/System Miami/Assets/_Project/Dungeon/UI/Alec Random Stuff/PopUpHandler.cs
@@ -1,10 +1,10 @@
 using SystemMiami.Management;
-using SystemMiami.ui;
 using SystemMiami.Utilities;
 using UnityEngine;
 using UnityEngine.UI;
+using SystemMiami.CombatRefactor;
 
-namespace SystemMiami
+namespace SystemMiami.ui
 {
     public class PopUpHandler : Singleton<PopUpHandler>
     {
@@ -13,6 +13,9 @@ namespace SystemMiami
         public RectTransform Popup;
         public Text ItemName;
         public Text DescriptionText;
+        public Text CooldownIndicator;
+        [TextArea] public string enabledStr;
+        [TextArea] public string cooldownStr;
 
         public ItemData CurrentItemData;
         public Vector2 offset;
@@ -38,6 +41,20 @@ namespace SystemMiami
         // PUBLIC
         public void OpenPopup(ItemData itemData, ActionQuickslot slot)
         {
+            OpenPopup(itemData, slot.RT, true);
+        }
+
+        public void OpenPopup(CombatAction combatAction, ActionQuickslot slot)
+        {
+            ItemData itemData = Database.MGR.GetDataWithJustID(combatAction.ID);
+
+            if (combatAction is NewAbility ability)
+            {
+                CooldownIndicator.text = ability.IsOnCooldown
+                    ? cooldownStr.Replace("<>", ability.CooldownRemaining.ToString())
+                    : enabledStr;
+            }
+
             OpenPopup(itemData, slot.RT, true);
         }
 
@@ -82,10 +99,9 @@ namespace SystemMiami
                     //);
             }
 
-
             // Set the text in the popup
             BindText();
-        }
+        }        
 
         public void ClosePopup()
         {

--- a/System Miami/Assets/_Project/Inventory/UI/Item Grid/Scripts/InventoryItemSlot.cs
+++ b/System Miami/Assets/_Project/Inventory/UI/Item Grid/Scripts/InventoryItemSlot.cs
@@ -2,11 +2,10 @@ using System;
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
-using SystemMiami.CombatSystem;
 using UnityEngine.EventSystems;
 using SystemMiami.Utilities;
 
-namespace SystemMiami
+namespace SystemMiami.ui
 {
     [RequireComponent(typeof(RectTransform))]
     public class InventoryItemSlot : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IPointerDownHandler

--- a/System Miami/Assets/_Project/Neighborhood/Scenes/In Build/NEIGHBORHOOD.unity
+++ b/System Miami/Assets/_Project/Neighborhood/Scenes/In Build/NEIGHBORHOOD.unity
@@ -272,6 +272,11 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!224 &569431011 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2714981005219291665, guid: 3bcb65aae83dbb043a7e0ae0ec07130e, type: 3}
+  m_PrefabInstance: {fileID: 1330444464}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &650046896 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7294393382445971812, guid: fcbf0d5d9cda1e945b80ca514073055d, type: 3}
@@ -2953,6 +2958,85 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1280036016
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1280036017}
+  - component: {fileID: 1280036019}
+  - component: {fileID: 1280036018}
+  m_Layer: 5
+  m_Name: Status Indicator (TEMPORARY)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1280036017
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1280036016}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 569431011}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 20}
+  m_SizeDelta: {x: -40, y: 90}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!114 &1280036018
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1280036016}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: b22b76f43784e274f922bfd783a620e9, type: 3}
+    m_FontSize: 25
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 2
+    m_MaxSize: 300
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Item Description
+--- !u!222 &1280036019
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1280036016}
+  m_CullTransparentMesh: 1
 --- !u!1001 &1330444464
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2965,6 +3049,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Popups
       objectReference: {fileID: 0}
+    - target: {fileID: 1844531926071828556, guid: 3bcb65aae83dbb043a7e0ae0ec07130e, type: 3}
+      propertyPath: StatusIndicator
+      value: 
+      objectReference: {fileID: 1280036018}
     - target: {fileID: 4014363440436735761, guid: 3bcb65aae83dbb043a7e0ae0ec07130e, type: 3}
       propertyPath: m_LocalPosition.x
       value: 730.26575
@@ -3007,7 +3095,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 2714981005219291665, guid: 3bcb65aae83dbb043a7e0ae0ec07130e, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1280036017}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3bcb65aae83dbb043a7e0ae0ec07130e, type: 3}
 --- !u!114 &1335189737 stripped
@@ -6432,6 +6523,7 @@ MonoBehaviour:
   questChance: 0
   shopChance: 0
   npcInfo: {fileID: 11400000, guid: 40557af94cd9589468c04b0bc14ee1fb, type: 2}
+  <FarthestIntersetion>k__BackingField: {fileID: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/System Miami/Assets/_Project/UI Elements/Popups/PopupManager.prefab
+++ b/System Miami/Assets/_Project/UI Elements/Popups/PopupManager.prefab
@@ -45,9 +45,17 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _preserveBetweenScenes: 0
+  log:
+    showMessages: 1
   Popup: {fileID: 0}
   ItemName: {fileID: 0}
   DescriptionText: {fileID: 0}
+  StatusIndicator: {fileID: 0}
+  enabledStr: ENABLED
+  cooldownStr: 'ON COOLDOWN
+
+    Enabled in <> Turns'
+  usesRemainingStr: 'Uses Remaining: <>'
   CurrentItemData:
     ID: 0
     Icon: {fileID: 0}

--- a/System Miami/Assets/_Project/Utilities/Managers/UI.cs
+++ b/System Miami/Assets/_Project/Utilities/Managers/UI.cs
@@ -6,6 +6,7 @@ using SystemMiami.CombatSystem;
 using System.Collections.Generic;
 using SystemMiami.ui;
 using UnityEngine;
+using UnityEngine.Assertions;
 
 namespace SystemMiami.Management
 {
@@ -93,12 +94,14 @@ namespace SystemMiami.Management
                 combatant._inventory,
                 combatant);
 
+            Assert.IsNotNull(combatantLoadout);
+
             if (combatant is PlayerCombatant)
             {
                 FillLoadoutBars(combatantLoadout);
             }
 
-            CombatantLoadoutCreated.Invoke(combatantLoadout, combatant);
+            CombatantLoadoutCreated?.Invoke(combatantLoadout, combatant);
         }
 
         protected virtual void OnSlotClicked(ActionQuickslot slot)


### PR DESCRIPTION
Fixes #108 Investigate Cooldowns

## Ability Status
- Displays status of abilities in the popup
- Disables buttons if cooldown > 0

## Consumable Status
- Displays uses remaining

## Why it kind of sucks:
- popup window is still just a single thing that the popup manager has separate references to each element of.
- TODO popup manager is responsible for not just setting every element, but deciding what to enable / disable / set to certain values based on what types of things it gets passed, rather than just being passed all the information it needs, a type of window to open, or at least enough information to decide on what type, then just open that.
- Have to pass the combat action in order to get the cooldown
- but also passing ID to database to get name and description, even though it's all being stored on the slot